### PR TITLE
Allow users to regulate logging behavior

### DIFF
--- a/eodms_dds/log.py
+++ b/eodms_dds/log.py
@@ -1,0 +1,18 @@
+import logging
+import sys
+
+
+# Create a logger that behaves like "print"
+eodms_logger = logging.getLogger('eodms_dds')
+eodms_logger.addHandler(logging.StreamHandler(sys.stdout))
+eodms_logger.setLevel(logging.DEBUG)
+
+
+class _EODMSLogger(logging.LoggerAdapter):
+    def __init__(self, header: str, logger: logging.Logger):
+        super().__init__(logger)
+        self.header = header
+
+    def process(self, msg: str, kwargs):
+        # Apply header to message
+        return f"| {self.header} | {msg}", kwargs


### PR DESCRIPTION
I'd like to switch to the `eodms-dss` API; however, I am concerned about deploying something that logs access / refresh tokens https://github.com/eodms-sgdot/py-eodms-dds/issues/26. Logged tokens help when running manually, so I hesitate to remove the log outright, but they are not secure for an automated process (e.g. say the logs are saved to a file).

This MR replaces `print` calls with python logging -- as python logging can be regulated by setting the log level. For example, I plan to set the log level to INFO:

```
import eodms_dds

eodms_dds.eodms_logger.setLevel(logging.INFO)  # Log INFO level or higher
dds_api = eodms_dds.dds.DDS_API(...)  # Now tokens won't be logged, as they are a DEBUG log

# Users can remove handlers if they want to disable logging
eodms_logger.handlers.clear()

# Users can even add their own handlers
eodms_logger.addHandler(...)
```

Bonus: I noticed that the `self.header` pattern could be simplified by moving it into a `LoggerAdapter`.