### PR TITLE
Use _EODMSLogger

### DIFF
--- a/eodms_dds/aaa.py
+++ b/eodms_dds/aaa.py
@@ -176,7 +176,7 @@ class AAA_API():
         self.login_success = True
         self.response = None
 
-        self.logger = log.EODMSLogger('EODMS_AAA', log.eodms_logger)
+        self.logger = log._EODMSLogger('EODMS_AAA', log.eodms_logger)
 
     def get_access_token(self):
         """


### PR DESCRIPTION
I made a last minute change to https://github.com/eodms-sgdot/py-eodms-dds/pull/30 after testing to make the `_EODMSLogger`  private by following the single underscore convention. I missed a spot during this rename.

Resolves https://github.com/eodms-sgdot/py-eodms-dds/issues/32. Thanks to @Naturrien for noticing