### PR TITLE
fix: Use content-type header to check if html, not json, returned

### DIFF
--- a/eodms_dds/dds.py
+++ b/eodms_dds/dds.py
@@ -51,11 +51,13 @@ class DDS_API():
             self.logger.info("Successfully got item using DDS API")
             try:
                 self.img_info = resp.json()
-            except:
-                resp_text = resp.text
-                if resp_text.content.startswith('<HTML>'):
+            except requests.exceptions.JSONDecodeError as exception:
+                content_type = resp.headers["Content-Type"]
+                if "text/html" in content_type:
                     self.logger.info("DDS API cannot be accessed at this time.")
                     return None
+                else:
+                    raise exception
         elif resp.status_code == 202:
             self.img_info = resp.json()
             status = self.img_info.get('status')


### PR DESCRIPTION
During ittermitant DDS API outage, DDS returns HTML content. The current implementation checks for HTML content with `resp_text.content.startswith('<HTML>')`, which fails becuse `resp_text.content` is of type `bytes`, not `str`. 

One fix would be `resp_text.content.startswith(b'<HTML>')`, but the response is not guranteed to begin with `<HTML>` (`curl https://www.eodms-sgdot.nrcan-rncan.gc.ca/` response begins with `<!DOCTYPE html>`). 

Instead, we can check that the header content-type contains `text/html`.