### PR TITLE
Environment trust flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ downloaded = proc_api.download_job_results(job_id, out_dir=f'./data/{job_id}')
 print(downloaded)
 ```
 
+### Environment and TLS Behavior
+
+The `--env` flag controls TLS verification behavior in the client, so you can keep proxy and CA environment variables set all the time without shell toggling.
+
+- `prod`
+  - Ignores CA-bundle environment variables (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`).
+  - Uses standard certificate verification (`verify=True`).
+- `staging`
+  - Requires `EODMS_STAGING_DOMAIN`.
+  - Uses `REQUESTS_CA_BUNDLE`, then `SSL_CERT_FILE`, then `CURL_CA_BUNDLE` when set.
+  - Falls back to insecure mode (`verify=False`) if no CA-bundle variable is set.
+
+Proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) are respected in both environments.
+
+This keeps EODMS credentials managed by the client while avoiding accidental auth side effects from ambient `.netrc` settings.
+
 ## Testing
 
 ### Clone Repository

--- a/eodms/aaa.py
+++ b/eodms/aaa.py
@@ -405,8 +405,8 @@ class AAA_API():
         
         # Send the request
         session = requests.Session()
-        session.trust_env = False
-        response = session.send(prepared, verify=self.verify_ssl)
+        proxies = requests.utils.get_environ_proxies(prepared.url)
+        response = session.send(prepared, verify=self.verify_ssl, proxies=proxies)
 
         #self.logger.info(f"response headers: {response.request.headers}")
 

--- a/eodms/config.py
+++ b/eodms/config.py
@@ -6,24 +6,33 @@ ssl._create_default_https_context = ssl._create_unverified_context
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
+def _resolve_staging_verify_ssl():
+    """Return staging TLS verify setting from env vars, falling back to insecure mode."""
+    for env_name in ("REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "CURL_CA_BUNDLE"):
+        ca_bundle = os.environ.get(env_name)
+        if ca_bundle:
+            return ca_bundle
+    return False
+
+
 def get_domain_config(environment='prod'):
     """
     Get domain configuration based on environment.
     
     :param environment: Environment type ('prod' or 'staging')
     :return: Dictionary with 'domain', 'verify_ssl' keys
+             verify_ssl may be bool or CA bundle path.
     """
     
     if environment == 'staging':
-        eodms_dir = os.path.expanduser('~/.eodms')
-
         return {
             'domain': os.environ['EODMS_STAGING_DOMAIN'],
-            #'ssl_cert_path': ssl_cert_path,
-            'verify_ssl': False  # Disable SSL verification for staging
+            # Use CA bundle env vars when available; otherwise retain legacy staging behavior.
+            'verify_ssl': _resolve_staging_verify_ssl(),
         }
     else:
         return {
             'domain': "https://www.eodms-sgdot.nrcan-rncan.gc.ca",
+            # Explicitly keep prod verification deterministic and independent of CA env vars.
             'verify_ssl': True
         }

--- a/eodms/dds.py
+++ b/eodms/dds.py
@@ -115,11 +115,16 @@ class DDS_API():
             if total_bytes is not None:
                 break
 
-        with requests.get(
-            download_url,
+        req = requests.Request("GET", download_url, headers=headers)
+        prepared = req.prepare()
+        session = requests.Session()
+        proxies = requests.utils.get_environ_proxies(prepared.url)
+
+        with session.send(
+            prepared,
             stream=True,
             verify=self.verify_ssl,
-            headers=headers,
+            proxies=proxies,
         ) as stream:
             stream.raise_for_status()
 

--- a/eodms/processes.py
+++ b/eodms/processes.py
@@ -82,8 +82,8 @@ class Processes_API:
         req = requests.Request(method, url, headers=headers, json=json_payload, params=params)
         prepared = req.prepare()
         session = requests.Session()
-        session.trust_env = False
-        return session.send(prepared, verify=self.verify_ssl)
+        proxies = requests.utils.get_environ_proxies(prepared.url)
+        return session.send(prepared, verify=self.verify_ssl, proxies=proxies)
 
     @staticmethod
     def _require_json(resp: requests.Response) -> Dict[str, Any]:

--- a/eodms/processes.py
+++ b/eodms/processes.py
@@ -265,7 +265,12 @@ class Processes_API:
         headers = self._apply_user_agent()
         self.logger.debug(f"Outbound User-Agent: {headers.get('User-Agent')}")
 
-        with requests.get(url, stream=True, verify=self.verify_ssl, headers=headers) as stream:
+        req = requests.Request('GET', url, headers=headers)
+        prepared = req.prepare()
+        session = requests.Session()
+        proxies = requests.utils.get_environ_proxies(prepared.url)
+
+        with session.send(prepared, stream=True, verify=self.verify_ssl, proxies=proxies) as stream:
             stream.raise_for_status()
             with open(out_file, 'wb') as pipe:
                 with tqdm.wrapattr(

--- a/eodms/search.py
+++ b/eodms/search.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, unquote, urlparse
+from copy import deepcopy
 
 import requests
 from pystac_client import Client, ItemSearch
@@ -13,7 +14,52 @@ from .__version__ import __version__
 from .errors import CatalogError, SearchError
 
 
+class _EODMSStacApiIO(StacApiIO):
+	"""StacApiIO variant that honors session.verify instead of forcing verify=True."""
+
+	def request(
+		self,
+		href: str,
+		method: str | None = None,
+		headers: dict[str, str] | None = None,
+		parameters: dict[str, Any] | None = None,
+	) -> str:
+		if method == "POST":
+			request = requests.Request(method=method, url=href, headers=headers, json=parameters)
+		else:
+			params = deepcopy(parameters) or {}
+			request = requests.Request(method="GET", url=href, headers=headers, params=params)
+
+		try:
+			modified = self._req_modifier(request) if self._req_modifier else None
+			prepped = self.session.prepare_request(modified or request)
+			send_kwargs = {
+				"proxies": dict(self.session.proxies or {}),
+				"verify": self.session.verify,
+				"cert": None,
+				"stream": False,
+			}
+			resp = self.session.send(prepped, timeout=self.timeout, **send_kwargs)
+		except Exception as err:
+			raise APIError(str(err)) from err
+
+		if resp.status_code != 200:
+			raise APIError.from_response(resp)
+
+		try:
+			return resp.content.decode("utf-8")
+		except Exception as err:
+			raise APIError(str(err)) from err
+
+
 class Search_API:
+	@staticmethod
+	def _is_cert_verify_error(exc: Exception) -> bool:
+		if isinstance(exc, requests.exceptions.SSLError):
+			return True
+		msg = str(exc).lower()
+		return "certificate verify failed" in msg or "certificate_verify_failed" in msg
+
 	@staticmethod
 	def _default_user_agent() -> str:
 		return f"{requests.utils.default_user_agent()} eodms-py/{__version__}"
@@ -61,6 +107,7 @@ class Search_API:
 		domain = domain_config['domain']
 		self.search_endpoint = f"{domain}/search"
 		verify_ssl = domain_config.get('verify_ssl', True)
+		is_staging = environment == 'staging'
 		self.logger = api_logger.EODMSLogger('eodms_search', api_logger.get_logger('search'))
 		self._catalog_auth_label = 'unauthenticated'
 
@@ -70,8 +117,10 @@ class Search_API:
 			self.logger.debug(f"Using {self._catalog_auth_label} catalog: {method} {url}")
 			return req
 
-		stac_api_io = StacApiIO(request_modifier=_log_stac_request)
+		stac_api_io = _EODMSStacApiIO(request_modifier=_log_stac_request)
 		stac_api_io.session.verify = verify_ssl
+		stac_api_io.session.proxies.update(requests.utils.get_environ_proxies(self.search_endpoint))
+		stac_api_io.session.trust_env = False
 		stac_api_io.session.headers.update({"User-Agent": self._default_user_agent()})
 		self.logger.debug(
 			f"Outbound User-Agent: {stac_api_io.session.headers.get('User-Agent')}"
@@ -95,36 +144,49 @@ class Search_API:
 					self.logger.warning(f"Authentication unavailable; continuing unauthenticated. Details: {aaa_api.last_error}")
 				self.logger.warning("Authentication token unavailable; using unauthenticated catalog access.")
 
-		try:
-			self.client = Client.open(
+		def _open_client():
+			return Client.open(
 				self.search_endpoint,
 				stac_io=stac_api_io,
 				request_modifier=_log_stac_request,
 			)
+
+		try:
+			self.client = _open_client()
 		except (APIError, Exception) as e:
+			root_exc = e
+
+			if is_staging and isinstance(verify_ssl, str) and self._is_cert_verify_error(e):
+				self.logger.warning(
+					"Staging catalog TLS verification failed using configured CA bundle; "
+					"retrying with verify=False."
+				)
+				stac_api_io.session.verify = False
+				try:
+					self.client = _open_client()
+					return
+				except (APIError, Exception) as fallback_exc:
+					root_exc = fallback_exc
+
 			if auth_enabled:
 				# Fallback when AAA is temporarily unhealthy or token is invalid/expired.
 				self.logger.error(
 					"Authenticated catalog initialization failed; "
 					"retrying unauthenticated access. "
-					f"Details: {e}"
+					f"Details: {root_exc}"
 				)
 				stac_api_io.session.headers.pop("Authorization", None)
 				self._catalog_auth_label = 'unauthenticated'
 				try:
-					self.client = Client.open(
-						self.search_endpoint,
-						stac_io=stac_api_io,
-						request_modifier=_log_stac_request,
-					)
+					self.client = _open_client()
 				except Exception as fallback_error:
 					self.logger.error(f"Unauthenticated catalog initialization failed: {fallback_error}")
 					raise CatalogError(
 						f"Unable to initialize STAC catalog after authentication fallback: {fallback_error}"
 					) from fallback_error
 			else:
-				self.logger.error(f"Catalog initialization failed: {e}")
-				raise CatalogError(f"Unable to initialize STAC catalog: {e}") from e
+				self.logger.error(f"Catalog initialization failed: {root_exc}")
+				raise CatalogError(f"Unable to initialize STAC catalog: {root_exc}") from root_exc
 		self.client.add_conforms_to("FILTER")
 		self.client.add_conforms_to("QUERY")
 
@@ -177,12 +239,9 @@ class Search_API:
 		"""Normalize a CQL2 text filter string."""
 		if not filter_text:
 			return None
-
-		filter_text = filter_text.strip()
-		if not filter_text:
+		if not filter_text.strip():
 			return None
 
-		# Normalize compact comparisons like "field=16" to "field = 16".
 		filter_text = re.sub(r"\s*(<=|>=|<>|=|<|>)\s*", r" \1 ", filter_text)
 		filter_text = re.sub(r"\s+", " ", filter_text).strip()
 
@@ -194,7 +253,7 @@ class Search_API:
 		geometry_field: str = "geometry",
 		spatial_op: str = "S_INTERSECTS",
 	) -> Optional[str]:
-		"""Build a CQL2 spatial expression from a WKT geometry string."""
+		"""Build a CQL2 spatial predicate from WKT geometry."""
 		if not geometry_wkt:
 			return None
 
@@ -203,7 +262,6 @@ class Search_API:
 			return None
 
 		op = (spatial_op or "S_INTERSECTS").strip().upper()
-		# Gracefully normalize the common singular alias to server-supported plural form.
 		if op == "S_INTERSECT":
 			op = "S_INTERSECTS"
 

--- a/tests/test_proxy_env.py
+++ b/tests/test_proxy_env.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import requests
+
+from eodms.aaa import AAA_API
+from eodms.processes import Processes_API
+
+
+class _AdapterResponse(requests.Response):
+    def __init__(self, request):
+        super().__init__()
+        self.status_code = 200
+        self._content = b"{}"
+        self.headers["Content-Type"] = "application/json"
+        self.url = request.url
+        self.request = request
+
+
+def _capture_proxies(monkeypatch):
+    captured = []
+
+    def fake_send(self, request, **kwargs):
+        captured.append(kwargs.get("proxies"))
+        return _AdapterResponse(request)
+
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", fake_send)
+    return captured
+
+
+def _capture_authorization(monkeypatch):
+    captured = []
+
+    def fake_send(self, request, **kwargs):
+        captured.append(request.headers.get("Authorization"))
+        return _AdapterResponse(request)
+
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", fake_send)
+    return captured
+
+
+def test_aaa_prepare_request_uses_https_proxy_env(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    captured = _capture_proxies(monkeypatch)
+
+    api = AAA_API("demo-user", "demo-pass", "prod")
+    api.prepare_request("https://example.com/aaa/v1/login")
+
+    assert captured == [{"https": "http://proxy.example.com:3128"}]
+
+
+def test_processes_send_request_uses_https_proxy_env(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    captured = _capture_proxies(monkeypatch)
+
+    api = Processes_API(environment="prod")
+    api._send_request("/processes")
+
+    assert captured == [{"https": "http://proxy.example.com:3128"}]
+
+
+def test_aaa_prepare_request_ignores_netrc_auth_while_using_proxy_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    Path(tmp_path / "_netrc").write_text(
+        "machine example.com login wrong-user password wrong-pass\n",
+        encoding="utf-8",
+    )
+
+    captured = _capture_authorization(monkeypatch)
+
+    api = AAA_API("demo-user", "demo-pass", "prod")
+    api.prepare_request("https://example.com/aaa/v1/login", method="POST", json={"username": "demo-user", "password": "demo-pass"})
+
+    assert captured == [None]

--- a/tests/test_proxy_env.py
+++ b/tests/test_proxy_env.py
@@ -38,6 +38,17 @@ def _capture_authorization(monkeypatch):
     return captured
 
 
+def _capture_verify(monkeypatch):
+    captured = []
+
+    def fake_send(self, request, **kwargs):
+        captured.append(kwargs.get("verify"))
+        return _AdapterResponse(request)
+
+    monkeypatch.setattr(requests.adapters.HTTPAdapter, "send", fake_send)
+    return captured
+
+
 def test_aaa_prepare_request_uses_https_proxy_env(monkeypatch):
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example.com:3128")
     monkeypatch.delenv("NO_PROXY", raising=False)
@@ -76,3 +87,30 @@ def test_aaa_prepare_request_ignores_netrc_auth_while_using_proxy_env(monkeypatc
     api.prepare_request("https://example.com/aaa/v1/login", method="POST", json={"username": "demo-user", "password": "demo-pass"})
 
     assert captured == [None]
+
+
+def test_aaa_prepare_request_uses_ca_bundle_on_staging(monkeypatch, tmp_path):
+    ca_bundle = str(tmp_path / "staging-ca.pem")
+    Path(ca_bundle).write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.setenv("EODMS_STAGING_DOMAIN", "https://staging.example.com")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_bundle)
+    captured = _capture_verify(monkeypatch)
+
+    api = AAA_API("demo-user", "demo-pass", "staging")
+    api.prepare_request("https://example.com/aaa/v1/login")
+
+    assert captured == [ca_bundle]
+
+
+def test_aaa_prepare_request_ignores_ca_bundle_env_on_prod(monkeypatch, tmp_path):
+    ca_bundle = str(tmp_path / "prod-ca-ignored.pem")
+    Path(ca_bundle).write_text("placeholder", encoding="utf-8")
+
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_bundle)
+    captured = _capture_verify(monkeypatch)
+
+    api = AAA_API("demo-user", "demo-pass", "prod")
+    api.prepare_request("https://example.com/aaa/v1/login")
+
+    assert captured == [True]

--- a/tests/test_search_queryables.py
+++ b/tests/test_search_queryables.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from eodms.search import Search_API
+from eodms.errors import CatalogError
 
 
 REAL_SATELLITE_ID = "RCM-1"
@@ -394,6 +395,53 @@ def test_get_item_returns_none_for_unknown_collection(capsys):
     captured = capsys.readouterr()
     assert item is None
     assert "Collection not found: UnknownCollection" in captured.out
+
+
+def test_search_api_staging_retries_without_verify_on_cert_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("EODMS_STAGING_DOMAIN", "https://staging.example.com")
+    ca_bundle = str(tmp_path / "staging-ca.pem")
+    with open(ca_bundle, "w", encoding="utf-8") as f:
+        f.write("placeholder")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_bundle)
+
+    verify_values = []
+
+    def fake_open(url, headers=None, parameters=None, ignore_conformance=None, modifier=None, request_modifier=None, stac_io=None, timeout=None):
+        verify_values.append(stac_io.session.verify)
+        if len(verify_values) == 1:
+            raise requests.exceptions.SSLError("CERTIFICATE_VERIFY_FAILED")
+
+        class _Client:
+            pass
+
+        return _Client()
+
+    monkeypatch.setattr("eodms.search.Client.open", fake_open)
+
+    Search_API(None, "staging")
+
+    assert verify_values == [ca_bundle, False]
+
+
+def test_search_api_prod_does_not_retry_without_verify_on_cert_failure(monkeypatch, tmp_path):
+    ca_bundle = str(tmp_path / "prod-ca.pem")
+    with open(ca_bundle, "w", encoding="utf-8") as f:
+        f.write("placeholder")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_bundle)
+
+    call_count = 0
+
+    def fake_open(url, headers=None, parameters=None, ignore_conformance=None, modifier=None, request_modifier=None, stac_io=None, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        raise requests.exceptions.SSLError("CERTIFICATE_VERIFY_FAILED")
+
+    monkeypatch.setattr("eodms.search.Client.open", fake_open)
+
+    with pytest.raises(CatalogError, match="Unable to initialize STAC catalog"):
+        Search_API(None, "prod")
+
+    assert call_count == 1
 
 
 @pytest.mark.integration


### PR DESCRIPTION
README excerpt:

### Environment and TLS Behavior

The `--env` flag controls TLS verification behavior in the client, so you can keep proxy and CA environment variables set all the time without shell toggling.

- `prod`
  - Ignores CA-bundle environment variables (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`).
  - Uses standard certificate verification (`verify=True`).
- `staging`
  - Requires environment variable `EODMS_STAGING_DOMAIN`.
  - Uses `REQUESTS_CA_BUNDLE`, then `SSL_CERT_FILE`, then `CURL_CA_BUNDLE` when set.
  - Falls back to insecure mode (`verify=False`) if no CA-bundle variable is set.

Proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) are now respected in both environments.

This keeps EODMS credentials managed by the client while avoiding accidental auth side effects from ambient `.netrc` settings.